### PR TITLE
fix: Production 24/7 Stability Improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # ═══════════════════════════════════════════════════════════════
 
 # Stage 1: Build
-FROM rust:1.82-bookworm AS builder
+FROM rust:1.85-bookworm AS builder
 
 WORKDIR /build
 

--- a/crates/bizclaw-gateway/src/server.rs
+++ b/crates/bizclaw-gateway/src/server.rs
@@ -583,7 +583,36 @@ pub async fn start(config: &GatewayConfig) -> anyhow::Result<()> {
 
     tracing::info!("🌐 Gateway server listening on http://{}", addr);
 
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
     Ok(())
+}
+
+/// Listen for shutdown signals (Ctrl+C / SIGTERM) for graceful shutdown.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+
+    tracing::info!("🛑 Shutdown signal received — draining connections...");
 }
 


### PR DESCRIPTION
## Summary

This PR fixes several issues that prevent BizClaw from running reliably 24/7 in production.

## Changes

### 1. Fix Dockerfile Rust Version Mismatch
- **Problem:** Dockerfile uses `rust:1.82-bookworm` but `Cargo.toml` requires `rust-version = 1.85` (edition 2024). Docker build **fails**.
- **Fix:** Updated to `rust:1.85-bookworm`

### 2. Add Graceful Shutdown for Gateway Server
- **Problem:** `axum::serve(listener, app).await` doesn't handle SIGTERM/SIGINT. Server kills in-flight requests on shutdown.
- **Fix:** Added `with_graceful_shutdown(shutdown_signal())` that listens for Ctrl+C and SIGTERM, drains connections gracefully.

### 3. Persist JWT Secret to File
- **Problem:** When `JWT_SECRET` env var is not set, a random secret is generated on each restart, invalidating all active tokens.
- **Fix:** JWT secret is now persisted to `~/.bizclaw/.jwt_secret` file on first run and reloaded on subsequent starts. File has chmod 600 on Unix.

### 4. Channel Auto-Reconnect with Exponential Backoff
- **Problem:** Channel streams (Telegram, Discord, Email) silently die when disconnected, with only a warning log.
- **Fix:** Added `run_channel_loop_with_reconnect()` wrapper with exponential backoff (5s to 300s max). Channels automatically reconnect after disconnect.

## Testing
- `cargo build --release --workspace` passes (0 errors, only pre-existing dead_code warnings)
- Existing test suite passes (1 pre-existing failure in `bizclaw-runtime::test_execute_echo` — uses `sh -c` which is unavailable on Windows)

## No Breaking Changes
All changes are backward-compatible. No new dependencies added.